### PR TITLE
Automatically update the ThemeKit binary to a specific version after install

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,11 +2,18 @@
 const parsedArgv = require('minimist')(process.argv.slice(2));
 
 const install = require('./install');
+const update = require('./update');
 const logger = require('./logger')();
 const runExecutable = require('./run-executable');
+const config = require('./config');
 
 if (parsedArgv._[0] === 'install') {
-  install(parsedArgv);
+  install(parsedArgv)
+    .then(() => {
+      if (config.update) {
+        update(parsedArgv, config.update.version)
+      }
+    })
 } else {
   runExecutable(process.argv.slice(2), process.cwd(), parsedArgv.logLevel)
     .catch((err) => {

--- a/lib/update.js
+++ b/lib/update.js
@@ -9,7 +9,7 @@ const config = require('./config');
  * @param {string} logLevel   Log level
  * @param {string} version   Version
  */
-async function upgrade(logLevel, version) {
+async function update(logLevel, version) {
   const logger = require('./logger')(logLevel)
   
   logger.silly('Theme Kit update starting');
@@ -23,9 +23,10 @@ async function upgrade(logLevel, version) {
     spinner.stop();
     logger.info(`Theme Kit path: ${pathToExecutable}`);
   } catch (err) {
-    logger.error(err);
-    process.exit(1);
+    throw new Error(err)
+    // logger.error(err);
+    // process.exit(1);
   }
 }
 
-module.exports = upgrade
+module.exports = update

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,0 +1,31 @@
+const runExecutable = require('./run-executable');
+const spinner = require('simple-spinner');
+
+const config = require('./config');
+
+/**
+ * Updates the Theme Kit executable to a specific version after install.
+ * Called if there is an upgrade key in the config.
+ * @param {string} logLevel   Log level
+ * @param {string} version   Version
+ */
+async function upgrade(logLevel, version) {
+  const logger = require('./logger')(logLevel)
+  
+  logger.silly('Theme Kit update starting');
+  spinner.start();
+
+  const { destination, binName } = config;
+  const pathToExecutable = `${destination}/${binName}`;
+
+  try {
+    await runExecutable(['update', `--version=v${version}`], process.cwd(), logLevel)
+    spinner.stop();
+    logger.info(`Theme Kit path: ${pathToExecutable}`);
+  } catch (err) {
+    logger.error(err);
+    process.exit(1);
+  }
+}
+
+module.exports = upgrade

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const runExecutable = require('./run-executable');
 const spinner = require('simple-spinner');
 
@@ -9,7 +10,7 @@ const config = require('./config');
  * @param {string} logLevel   Log level
  * @param {string} version   Version
  */
-async function update(logLevel, version) {
+async function update(logLevel) {
   const logger = require('./logger')(logLevel)
   
   logger.silly('Theme Kit update starting');
@@ -18,14 +19,14 @@ async function update(logLevel, version) {
   const { destination, binName } = config;
   const pathToExecutable = `${destination}/${binName}`;
 
+  const version = config.update.version;
+
   try {
     await runExecutable(['update', `--version=v${version}`], process.cwd(), logLevel)
     spinner.stop();
     logger.info(`Theme Kit path: ${pathToExecutable}`);
   } catch (err) {
     throw new Error(err)
-    // logger.error(err);
-    // process.exit(1);
   }
 }
 


### PR DESCRIPTION
**What**
Add the option to automatically update the ThemeKit binary to a specific version after installation

**Why**
Useful when you want a specific version of ThemeKit, e.g. testing a pre release or using it in your CI/CD workflow

**How**
in lib/config.js, add an update object with the version as a key, for example:

<pre>
const path = require('path');

module.exports = {
  baseURL: 'https://shopify-themekit.s3.amazonaws.com',
  version: '1.1.1',
  update: {
    version: '1.1.3-pre'
  },
  destination: path.join(__dirname, '..', 'bin'),
  binName: process.platform === 'win32' ? 'theme.exe' : 'theme'
};
</pre>